### PR TITLE
Fixing Invalid Host Header error from webpack by disabling check

### DIFF
--- a/linux-container-workshop/app/web/webpack.config.js
+++ b/linux-container-workshop/app/web/webpack.config.js
@@ -96,6 +96,7 @@ module.exports = {
     },
     host: '0.0.0.0',
     port: 8080,
+    disableHostCheck: true,
     before(app) {
       app.use((req, res, next) => {
         console.log(`ENV IMAGE_TAG: `, process.env.IMAGE_TAG);


### PR DESCRIPTION
Lab 1 suggests hitting public DNS endpoint of VM to test web front-end, but Webpack is listening to 0.0.0.0, and doesn't recognize the host header. Simple fix to remove host check for lab purposes.