### PR TITLE
Fix kubectl proxy command

### DIFF
--- a/linux-container-workshop/hol-content/05-kubernetes-ui.md
+++ b/linux-container-workshop/hol-content/05-kubernetes-ui.md
@@ -17,7 +17,7 @@ There are multiple ways of accessing Kubernetes dashboard. You can access throug
     * Run ```az aks get-credentials -n $CLUSTER_NAME -g $NAME``` in order to get the credentials to access our managed Kubernetes cluster in Azure
     * Run ```az aks browse -n $CLUSTER_NAME -g $NAME```
     * This creates a local proxy to 127.0.0.1:8001
-    * Open a web browser (Firefox is pre-installed on the Jumpbox) and point to: <http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#!/cluster?namespace=default>
+    * Open a web browser (Firefox is pre-installed on the Jumpbox) and point to: <http://127.0.0.1:8001/>
 
 ### Explore Kubernetes Dashboard
 

--- a/linux-container-workshop/hol-content/05-kubernetes-ui.md
+++ b/linux-container-workshop/hol-content/05-kubernetes-ui.md
@@ -15,7 +15,7 @@ There are multiple ways of accessing Kubernetes dashboard. You can access throug
     * Run ```NAME=$(az group list | jq '.[0]."name"' -r)``` in order to retrieve the name of the resource group for your Azure account
     * Run ```CLUSTER_NAME="${NAME//_}"``` in order to retrieve the cluster name (to remove the underscore)
     * Run ```az aks get-credentials -n $CLUSTER_NAME -g $NAME``` in order to get the credentials to access our managed Kubernetes cluster in Azure
-    * Run ```kubectl proxy```
+    * Run ```az aks browse -n $CLUSTER_NAME -g $NAME```
     * This creates a local proxy to 127.0.0.1:8001
     * Open a web browser (Firefox is pre-installed on the Jumpbox) and point to: <http://127.0.0.1:8001/api/v1/proxy/namespaces/kube-system/services/kubernetes-dashboard/#!/cluster?namespace=default>
 


### PR DESCRIPTION
kubectl proxy seems not to work, initial redirect from /ui works, but kube dashboard loads empty, with the following errors. 
GET 
http://localhost:9090/api/v1/namespaces/kube-system/services/kubernetes-dashboard/static/vendor.9aa0b786.css [HTTP/1.1 404 Not Found 21ms]
GET 
http://localhost:9090/api/v1/namespaces/kube-system/services/kubernetes-dashboard/static/app.8ebf2901.css [HTTP/1.1 404 Not Found 20ms]
GET 
http://localhost:9090/api/v1/namespaces/kube-system/services/kubernetes-dashboard/static/vendor.840e639c.js [HTTP/1.1 404 Not Found 19ms]
GET 
http://localhost:9090/api/v1/namespaces/kube-system/services/kubernetes-dashboard/api/appConfig.json [HTTP/1.1 404 Not Found 24ms]
GET 
http://localhost:9090/api/v1/namespaces/kube-system/services/kubernetes-dashboard/static/app.68d2caa2.js [HTTP/1.1 404 Not Found 27ms]
GET 
http://localhost:9090/api/v1/namespaces/kube-system/services/kubernetes-dashboard/static/app.68d2caa2.js

Swapping command for aks browse seems to work as expected