### PR TITLE
Fix az akz command to get k8s versions

### DIFF
--- a/labs/day1-labs/10-cluster-upgrading.md
+++ b/labs/day1-labs/10-cluster-upgrading.md
@@ -4,7 +4,7 @@ Azure Container Service (AKS) makes it easy to perform common management tasks i
 
 ## Upgrade an AKS cluster
 
-Before upgrading a cluster, use the `az aks get-upgrades` command to check which Kubernetes releases are available for upgrade.
+Before upgrading a cluster, use the `az aks get-versions` command to check which Kubernetes releases are available for upgrade.
 
 ```azurecli-interactive
 az aks get-upgrades --name $CLUSTER_NAME --resource-group $NAME --output table


### PR DESCRIPTION
The "az aks get-upgrades" command is now "az aks get-versions".

  $ az aks --help
    ...
    get-versions     : Get versions available to upgrade a managed Kubernetes cluster.

Signed-off-by: Francis Giraldeau <francis.giraldeau@gmail.com>