### PR TITLE
Add note for potential length of upgrade process

### DIFF
--- a/labs/day1-labs/10-cluster-upgrading.md
+++ b/labs/day1-labs/10-cluster-upgrading.md
@@ -6,6 +6,8 @@ Azure Container Service (AKS) makes it easy to perform common management tasks i
 
 Before upgrading a cluster, use the `az aks get-upgrades` command to check which Kubernetes releases are available for upgrade.
 
+*NOTE:  This operation could take ~1 hour*
+
 ```azurecli-interactive
 az aks get-upgrades --name $CLUSTER_NAME --resource-group $NAME --output table
 ```


### PR DESCRIPTION
When working with a partner on this lab, they started the upgrade process and we were hesitant to perform any additional kubectl commands during the process.  We believed that making a note of the upgrade time might help them plan out the workshop timeline better.