### PR TITLE
Fixed License link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ## License
 
-This software is covered under the MIT license. You can read the license [here][license].
+This software is covered under the MIT license. You can read the license [here](LICENSE).
 
 This software contains code from Heroku Buildpacks, which are also covered by the MIT license.
 


### PR DESCRIPTION
In the license section of the Readme there is a reference to the license. 
But the link is not working because the brackets for the file to link were wrong. 

Im not quite sure if this is the expected behaviour so I have linked the license file in the root directory of the repository to the readme file. 

If you wont that new behaviour just give me an info and I will close this PR.

Thanks for sharing this workshop material!

