### PR TITLE
K8S 1.11.2

### DIFF
--- a/labs/day1-labs/03-create-aks-cluster.md
+++ b/labs/day1-labs/03-create-aks-cluster.md
@@ -56,14 +56,14 @@
     
     ```
 
-8. Create your AKS cluster in the resource group created above with 2 nodes, targeting Kubernetes version 1.11.1
+8. Create your AKS cluster in the resource group created above with 2 nodes, targeting Kubernetes version 1.11.2
     ```
     # This command can take 5-25 minutes to run as it is creating the AKS cluster. Please be PATIENT...
     
     # set the location to one of the provided AKS locations (eg - centralus, eastus)
     LOCATION=
 
-    az aks create -n $CLUSTER_NAME -g $NAME -c 2 -k 1.11.1 --generate-ssh-keys -l $LOCATION
+    az aks create -n $CLUSTER_NAME -g $NAME -c 2 -k 1.11.2 --generate-ssh-keys -l $LOCATION
     ```
 
 9. Verify your cluster status. The `ProvisioningState` should be `Succeeded`
@@ -72,7 +72,7 @@
 
     Name                 Location    ResourceGroup         KubernetesVersion    ProvisioningState    Fqdn
     -------------------  ----------  --------------------  -------------------  -------------------  -------------------------------------------------------------------
-    ODLaks-v2-gbb-16502  centralus   ODL_aks-v2-gbb-16502  1.11.1                Succeeded             odlaks-v2--odlaks-v2-gbb-16-b23acc-17863579.hcp.centralus.azmk8s.io
+    ODLaks-v2-gbb-16502  centralus   ODL_aks-v2-gbb-16502  1.11.2                Succeeded             odlaks-v2--odlaks-v2-gbb-16-b23acc-17863579.hcp.centralus.azmk8s.io
     ```
 
 
@@ -89,8 +89,8 @@
     kubectl get nodes
     
     NAME                       STATUS    ROLES     AGE       VERSION
-    aks-nodepool1-20004257-0   Ready     agent     4m        v1.11.1
-    aks-nodepool1-20004257-1   Ready     agent     4m        v1.11.1
+    aks-nodepool1-20004257-0   Ready     agent     4m        v1.11.2
+    aks-nodepool1-20004257-1   Ready     agent     4m        v1.11.2
     ```
     
     To see more details about your cluster: 

--- a/labs/day1-labs/06-monitoring-k8s.md
+++ b/labs/day1-labs/06-monitoring-k8s.md
@@ -32,8 +32,8 @@ We are going to be installing Prometheus and Grafana into our K8s cluster using 
     ```
     helm version
     # You should see something like the following as output:
-    Client: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
-    Server: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
+    Client: &version.Version{SemVer:"v2.11.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
+    Server: &version.Version{SemVer:"v2.11.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
     ```
 
 ## Install Prometheus using Helm

--- a/labs/day1-labs/07-cluster-scaling.md
+++ b/labs/day1-labs/07-cluster-scaling.md
@@ -49,8 +49,8 @@ heroes-web-3683626428-zxp2s                                       1/1       Runn
 kubectl get nodes
 # You should see something like the following as output (there is one node in the cluster):
 NAME                       STATUS    ROLES     AGE       VERSION
-aks-nodepool1-42552728-0   Ready     agent     4h        v1.11.1
-aks-nodepool1-42552728-1   Ready     agent     4h        v1.11.1
+aks-nodepool1-42552728-0   Ready     agent     4h        v1.11.2
+aks-nodepool1-42552728-1   Ready     agent     4h        v1.11.2
 ```
 2. Scale out AKS cluster to accomodate the demand
 ```bash
@@ -68,10 +68,10 @@ az aks scale -g $RESOURCE_GROUP_NAME -n $AKS_CLUSTER_NAME --node-count 4
 kubectl get nodes
 # You should see something like the following as output (there are now 4 nodes in the cluster):
 NAME                       STATUS    ROLES     AGE       VERSION
-aks-nodepool1-42552728-0   Ready     agent     5h        v1.11.1
-aks-nodepool1-42552728-1   Ready     agent     5h        v1.11.1
-aks-nodepool1-42552728-2   Ready     agent     7m        v1.11.1
-aks-nodepool1-42552728-3   Ready     agent     7m        v1.11.1
+aks-nodepool1-42552728-0   Ready     agent     5h        v1.11.2
+aks-nodepool1-42552728-1   Ready     agent     5h        v1.11.2
+aks-nodepool1-42552728-2   Ready     agent     7m        v1.11.2
+aks-nodepool1-42552728-3   Ready     agent     7m        v1.11.2
 ```
 
 4. Re-visit Grafana Dasboard to validate cluster scale is working.

--- a/labs/day1-labs/10-cluster-upgrading.md
+++ b/labs/day1-labs/10-cluster-upgrading.md
@@ -17,13 +17,13 @@ Output:
 ```console
 Name     ResourceGroup    MasterVersion    NodePoolVersion       Upgrades
 -------  ---------------  ---------------  -------------------  -------------------
-default  myResourceGroup  1.11.1           1.11.1               1.11.2
+default  myResourceGroup  1.11.2           1.11.2               1.11.3
 ```
 
 In this case, we have one version available for upgrade: 1.11.2. We can use the `az aks upgrade` command to upgrade to the latest available version.  During the upgrade process, nodes are carefully [cordoned and drained][kubernetes-drain] to minimize disruption to running applications.  Before initiating a cluster upgrade, ensure that you have enough additional compute capacity to handle your workload as cluster nodes are added and removed.
 
 ```azurecli-interactive
-az aks upgrade --name $CLUSTER_NAME --resource-group $NAME --kubernetes-version 1.11.2
+az aks upgrade --name $CLUSTER_NAME --resource-group $NAME --kubernetes-version 1.11.3
 ```
 
 Output:
@@ -58,7 +58,7 @@ Output:
     ],
     "dnsPrefix": "myK8sClust-myResourceGroup-4f48ee",
     "fqdn": "myk8sclust-myresourcegroup-4f48ee-406cc140.hcp.eastus.azmk8s.io",
-    "kubernetesVersion": "1.11.2",
+    "kubernetesVersion": "1.11.3",
     "linuxProfile": {
       "adminUsername": "azureuser",
       "ssh": {
@@ -93,7 +93,7 @@ Output:
 ```json
 Name          Location    ResourceGroup    KubernetesVersion    ProvisioningState    Fqdn
 ------------  ----------  ---------------  -------------------  -------------------  ----------------------------------------------------------------
-myK8sCluster  eastus     myResourceGroup  1.11.2                Succeeded            myk8sclust-myresourcegroup-3762d8-2f6ca801.hcp.eastus.azmk8s.io
+myK8sCluster  eastus     myResourceGroup  1.11.3                Succeeded            myk8sclust-myresourcegroup-3762d8-2f6ca801.hcp.eastus.azmk8s.io
 ```
 
 ## Attribution:

--- a/labs/day2-labs/ingress-controller.md
+++ b/labs/day2-labs/ingress-controller.md
@@ -25,8 +25,8 @@ We will use Helm to install Nginx. We had configured Helm in prior labs.
     helm version
 
     # You should see something like the following as output:
-    Client: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
-    Server: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
+    Client: &version.Version{SemVer:"v2.11.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
+    Server: &version.Version{SemVer:"v2.11.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
     ```
 
     > Note: If helm was not configured, you must run `helm init`

--- a/labs/day2-labs/open-service-broker.md
+++ b/labs/day2-labs/open-service-broker.md
@@ -12,8 +12,8 @@ Note: the Kubernetes version of your cluster should be > 1.9.0, [otherwise you w
 
 ```bash
 odl_user@Azure:~$ helm version
-Client: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
-Server: &version.Version{SemVer:"v2.10.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
+Client: &version.Version{SemVer:"v2.11.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
+Server: &version.Version{SemVer:"v2.11.0", GitCommit:"9ad53aac42165a5fadc6c87be0dea6b115f93090", GitTreeState:"clean"}
 ```
 
 * If a newer version of Helm is required, click [here](https://docs.helm.sh/using_helm/#installing-helm) for instructions on installing and updating Helm.

--- a/labs/day2-labs/virtual-kubelet-aci.md
+++ b/labs/day2-labs/virtual-kubelet-aci.md
@@ -161,10 +161,10 @@ Output:
 
 ```console
 NAME                                           STATUS    ROLES     AGE       VERSION
-aks-nodepool1-24399631-0                       Ready     agent     3d        v1.11.1
-aks-nodepool1-24399631-1                       Ready     agent     3d        v1.11.1
-virtual-kubelet-virtual-kubelet-linux-eastus   Ready     agent     20m       v1.8.3
-virtual-kubelet-virtual-kubelet-linux-westus   Ready     agent     3m        v1.8.3
+aks-nodepool1-24399631-0                       Ready     agent     3d        v1.11.2
+aks-nodepool1-24399631-1                       Ready     agent     3d        v1.11.2
+virtual-kubelet-virtual-kubelet-linux-eastus   Ready     agent     20m       v1.11.2
+virtual-kubelet-virtual-kubelet-linux-westus   Ready     agent     3m        v1.11.2
 ```
 
 ## Schedule a pod in ACI


### PR DESCRIPTION
Since k8s 1.11.3 is integrated in AKS and according the new supported version policy, 1.11.1 is not anymore supported: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions#kubernetes-version-support-policy

And helm 2.11.0